### PR TITLE
Pin rust toolchain and pin csgo-gsi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/ui/main.rs"
 
 [dependencies]
 buttplug = "7.1.11"
-csgo-gsi = { features = ["rhai"], path = 'deps/csgo-gsi' }
+csgo-gsi = { features = ["rhai"], git = 'https://github.com/gloss-click/csgo-gsi.git' }
 rhai = { version = "0.18.3", features = ["sync"] }
 futures = "0.3.30"
 toml = "0.8.8"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.77.2"


### PR DESCRIPTION
In addition consider pinning rust toolchain or updating csgo-gsi dependencies. csgo-gsi depends on vdf-serde, which depends on nom v1.2.4 which wont get compiled in future rust versions. csgo-gsi directly depends on nom v1.2.4 too.