### PR TITLE
Add support for Linear devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,23 +64,43 @@ let falloff = 0.0;
 let kills = 0;
 let assists = 0;
 
+let steam_id = "";
+
 fn handle_update(update) {
     if update.player != () {
-        if update.player.match_stats != () {
-            if kills < update.player.match_stats.kills {
-                kills = update.player.match_stats.kills;
-                vibrate(0.3 + kills.to_float()/25.0, 1.0);
-            }
-            if assists < update.player.match_stats.assists {
-                assists = update.player.match_stats.assists;
-                vibrate(0.15, 1.0);
-            }
+        if steam_id == "" {
+            steam_id = update.player.steam_id;
+        }
+        if steam_id == update.player.steam_id {
+            if update.player.match_stats != () {
+                if kills < update.player.match_stats.kills {
+                    let kdiff = (update.player.match_stats.kills - kills);
+                    if kdiff > 5 {
+                        kdiff = 5;
+                    }
+                    for i in range(0, kdiff) {
+                        vibrate_index(kills.to_float()/50.0, 1.0, (kills + i) % 2);
+                        linear(500, 1.0);
+						sleep(0.5);
+						linear(500, 0.0);
+                    }
+                }
 
-            if update.player.match_stats.kills == 0 {
-                kills = 0;
-            }
-            if update.player.match_stats.assists == 0 {
-                assists = 0;
+                kills = update.player.match_stats.kills;
+
+                if assists < update.player.match_stats.assists {
+                    vibrate(0.15, 1.0);
+                    linear(500, 0.5);
+                }
+                
+                assists = update.player.match_stats.assists;
+
+                if update.player.match_stats.kills == 0 {
+                    kills = 0;
+                }
+                if update.player.match_stats.assists == 0 {
+                    assists = 0;
+                }
             }
         }
     }
@@ -96,7 +116,12 @@ That's why the example script checks if things are equal to `()`.
 All the enums defined by `csgo-gsi` can be `.to_string()`ed and tested against string values, like the default script does for `WeaponState`.
 All the maps get translated into Rhai maps; several of those should probably just be arrays in the first place, so go poke the `csgo-gsi` author about that if you need reasonable access to that data.
 
-The only command functions implemented are `vibrate(strength, duration_in_seconds)` and `stop()` but the infrastructure is there to add more.
+Command functions currently implemented are:
+- `vibrate(strength, duration in seconds)`
+- `vibrate_index(speed, duration in seconds, index of motor)`
+- `stop()`
+- `linear(duration in milliseconds, position in percent from 0.0 to 1.0)`
+- `sleep(duration in seconds);`
 
 Feel free to file a github issue for any problems you have and I'll try to take a look.
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ fn handle_update(update) {
                     for i in range(0, kdiff) {
                         vibrate_index(kills.to_float()/50.0, 1.0, (kills + i) % 2);
                         linear(500, 1.0);
-						sleep(0.5);
-						linear(500, 0.0);
+			sleep(0.5);
+			linear(500, 0.0);
                     }
                 }
 

--- a/src/buttplug.rs
+++ b/src/buttplug.rs
@@ -31,6 +31,7 @@ pub enum GuiEvent {
 pub enum BPCommand {
     Vibrate(f64),
     VibrateIndex(f64, u32),
+    Linear(u32, f64),
     Stop
 }
 
@@ -118,6 +119,9 @@ async fn run_buttplug(
                     }
                 }
                 info!("Intiface: Device added: {}", dev.name());
+                debug!("Device {} capabilities: vibrate: {}, linear: {}", dev.name(),
+                    !dev.vibrate_attributes().is_empty(),
+                    !dev.linear_attributes().is_empty());
                 enabled_devices.insert(dev.index());
             }
             Event::Buttplug(ButtplugClientEvent::DeviceRemoved(dev)) => {
@@ -150,32 +154,73 @@ async fn run_buttplug(
                 match command {
                     BPCommand::Vibrate(speed) => {
                         for device in client.devices() {
-                            if enabled_devices.contains(&device.index()) {
-                                info!("Setting speed {} across device {}", speed, &device.name());
-                                info!("Sending vibrate speed {} to device {}", speed, &device.name());
-                                device.vibrate(&ScalarValueCommand::ScalarValue(speed.min(1.0))).await.context("Couldn't send Vibrate command")?;
+                            if device.vibrate_attributes().is_empty() {
+                                debug!("Device {} does not support vibration attributes, skipping", device.name());
+                                continue;
                             }
-                        }
-                    },
-                    BPCommand::Stop => {
-                        for device in client.devices() {
-                            if enabled_devices.contains(&device.index()) {
-                                info!("Stopping device {}", &device.name());
-                                device.vibrate(&ScalarValueCommand::ScalarValue(0.0)).await.context("Couldn't send Stop command")?;
-                            }
+                            device.vibrate(&ScalarValueCommand::ScalarValue(speed.min(1.0)))
+                                .await
+                                .context("Couldn't send Vibrate command")?;
                         }
                     },
                     BPCommand::VibrateIndex(speed, index) => {
                         for device in client.devices() {
                             if enabled_devices.contains(&device.index()) {
-                                let nindex = index.min(device.linear_attributes().len() as u32 - 1); //I just replaced each vibration command with the corresponding linear command since I couldn't figure out how to add a new command
+                                let vibrate_len = device.vibrate_attributes().len() as u32;
+
+                                if vibrate_len == 0 { // Prevent underflow: Check if the device has any vibration attributes before performing subtraction
+                                    debug!("Device {} does not support vibration attributes, skipping", device.name());
+                                    continue;
+                                }
+                                
+                                let nindex = index.min(vibrate_len - 1); // Ensure index is within bounds
                                 info!("Setting speed {} on index {} on device {}", speed, nindex, &device.name());
-                                let map = HashMap::from([(nindex, (500 as u32, 0.20 as f64))]); //What am I even doing?
-                                device.linear(&LinearCommand::LinearMap(map)).await.context("Couldn't send VibrateIndex command")?;
+                                
+                                let map = HashMap::from([(nindex, speed.min(1.0))]);
+                                device.vibrate(&ScalarValueCommand::ScalarValueMap(map)).await.context("Couldn't send VibrateIndex command")?;
                             }
                         }
+                    },                                      
+                    BPCommand::Linear(duration, position) => {
+                        for device in client.devices() {
+                            if device.linear_attributes().is_empty() {  // Ensure the device has linear attributes before proceeding
+                                debug!("Device {} does not support linear movement, skipping", device.name());
+                                continue;
+                            }
+
+                            let max_index = device.linear_attributes().len() as u32;    // Safe handling: check if the device has at least one linear attribute
+                            
+                            if max_index > 0 {  // Prevent underflow: Making sure we don't subtract from zero
+                                let nindex = position.min((max_index - 1) as f64);
+                                info!("Setting linear position {} on device {}", position, device.name());
+                                let map = HashMap::from([(nindex as u32, (duration as u32, position.min(1.0)))]);
+                                device.linear(&LinearCommand::LinearMap(map))
+                                    .await
+                                    .context("Couldn't send Linear command")?;
+                            } else {
+                                debug!("Device {} does not support linear movement, skipping", device.name());
+                            }
+                        }
+                    },                                      
+                    BPCommand::Stop => {
+                        for device in client.devices() {
+                            if !device.vibrate_attributes().is_empty() {
+                                device.vibrate(&ScalarValueCommand::ScalarValue(0.0))
+                                    .await
+                                    .context("Couldn't send Stop command for vibration")?;
+                            }
+                            if !device.linear_attributes().is_empty() {
+                                let map = HashMap::from([(0, (0, 0.0))]);
+                                device.linear(&LinearCommand::LinearMap(map))
+                                    .await
+                                    .context("Couldn't send Stop command for linear movement")?;
+                            }
+                        }
+                    },
+                    _ => {
+                        debug!("Received unsupported command, ignoring.");
                     }
-                }
+                }                
             },
             Event::CloseCommand => {
                 info!("Buttplug thread asked to quit");

--- a/src/buttplug.rs
+++ b/src/buttplug.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Error};
 use buttplug::{
     client::{
         ButtplugClient,
-        ButtplugClientEvent, device::ScalarValueCommand
+        ButtplugClientEvent, device::ScalarValueCommand, device::LinearCommand
     },
     core::connector::{ButtplugRemoteClientConnector, ButtplugWebsocketClientTransport},
     core::message::serializer::ButtplugClientJSONSerializer,
@@ -168,10 +168,10 @@ async fn run_buttplug(
                     BPCommand::VibrateIndex(speed, index) => {
                         for device in client.devices() {
                             if enabled_devices.contains(&device.index()) {
-                                let nindex = index.min(device.vibrate_attributes().len() as u32 - 1);
+                                let nindex = index.min(device.linear_attributes().len() as u32 - 1); //I just replaced each vibration command with the corresponding linear command since I couldn't figure out how to add a new command
                                 info!("Setting speed {} on index {} on device {}", speed, nindex, &device.name());
-                                let map = HashMap::from([(nindex, speed.min(1.0))]);
-                                device.vibrate(&ScalarValueCommand::ScalarValueMap(map)).await.context("Couldn't send VibrateIndex command")?;
+                                let map = HashMap::from([(nindex, (500 as u32, 0.20 as f64))]); //What am I even doing?
+                                device.linear(&LinearCommand::LinearMap(map)).await.context("Couldn't send VibrateIndex command")?;
                             }
                         }
                     }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -5,7 +5,7 @@ use std::{env::current_exe, fs::{read_to_string, write}, io::stdin};
 
 use anyhow::{Context, Error};
 
-use cs2_buttplug::{async_main, async_main_with_buttplug, config::Config};
+use cs2_buttplug::{async_main_with_buttplug, config::Config};
 
 pub fn wait_for_enter() {
     let mut ignored = String::new();

--- a/src/default_script.rhai
+++ b/src/default_script.rhai
@@ -20,7 +20,10 @@ fn handle_update(update) {
                         kdiff = 5;
                     }
                     for i in range(0, kdiff) {
-                        vibrate_index(kills.to_float()/50.0, 1.0, (kills + i) % 2); 
+                        vibrate_index(kills.to_float()/50.0, 1.0, (kills + i) % 2);
+                        linear(500, 1.0);
+						sleep(0.5);
+						linear(500, 0.0);
                     }
                 }
 
@@ -28,6 +31,7 @@ fn handle_update(update) {
 
                 if assists < update.player.match_stats.assists {
                     vibrate(0.15, 1.0);
+                    linear(500, 0.5);
                 }
                 
                 assists = update.player.match_stats.assists;

--- a/src/script.rs
+++ b/src/script.rs
@@ -43,12 +43,21 @@ impl ScriptHost {
                 error!("Error sending command from script to buttplug: {}", err);
             }
         });
+        engine.register_fn("linear", move |duration: i64, position: f64| {
+            let result = send.send(ScriptCommand::Linear(duration as u32, position));
+            if let Err(err) = result {
+                error!("Error sending Linear command: {}", err);
+            }
+        });              
         engine.register_fn("stop", move || {
             let result = ssend.send(ScriptCommand::Stop);
             if let Err(err) = result {
                 error!("Error sending command from script to buttplug: {}", err);
             }
         });
+        engine.register_fn("sleep", |time: f64| {
+            std::thread::sleep(std::time::Duration::from_secs_f64(time));
+        });        
         engine.register_fn("log", move |msg: String| {
             info!("Script: {}", msg);
         });

--- a/src/timer_thread.rs
+++ b/src/timer_thread.rs
@@ -9,6 +9,7 @@ use crate::buttplug::BPCommand;
 pub enum ScriptCommand {
     VibrateFor(f64, f64),
     VibrateForWithIndex(f64, f64, u32),
+    Linear(u32, f64), // Duration in milliseconds, position as a percentage
     Stop,
     Close,
 }
@@ -41,6 +42,9 @@ async fn timer_thread(send: broadcast::Sender<BPCommand>, mut recv: broadcast::R
                     pqueue.insert(timestamp, BPCommand::VibrateIndex(strength, index));
                     pqueue.insert(timestamp + Duration::from_secs_f64(time), BPCommand::VibrateIndex(0.0, index));
                 },
+                ScriptCommand::Linear(duration, position) => {
+                    pqueue.insert(timestamp, BPCommand::Linear(duration, position));
+                },                
                 ScriptCommand::Stop => {
                     pqueue.insert(timestamp, BPCommand::Stop);
                 },

--- a/src/ui/main.rs
+++ b/src/ui/main.rs
@@ -1,13 +1,13 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use std::cell::{Cell, RefCell};
-use std::collections::{HashMap, HashSet};
+
+use std::collections::{HashMap};
 use std::future::IntoFuture;
 use std::path::PathBuf;
-use std::rc::Rc;
+
 use std::str::FromStr;
-use std::sync::{Arc, Mutex, RwLock};
-use buttplug::client;
+use std::sync::{Arc, Mutex};
+
 use eframe::egui;
 use cs2_buttplug::config::Config;
 use cs2_buttplug::{async_main, spawn_buttplug_client, ClientEvent, CloseEvent, GuiEvent};
@@ -324,14 +324,14 @@ impl eframe::App for CsButtplugUi {
 
             ui.heading("Game State");
 
-            egui::CollapsingHeader::new("Values").show(&mut ui, |mut ui| {
+            egui::CollapsingHeader::new("Values").show(&mut ui, |_ui| {
                 
             });
 
             ui.separator();
 
             egui::CollapsingHeader::new("Log").show(&mut ui, |mut ui| {
-                egui::ScrollArea::new([false, true]).max_height(100.0).stick_to_bottom(true).auto_shrink([false, true]).show(&mut ui, |ui| {
+                egui::ScrollArea::new([false, true]).stick_to_bottom(true).auto_shrink([false, true]).show(&mut ui, |ui| {
                     let logs = self.logs.lock().unwrap();
 
                     let log = logs.concat();


### PR DESCRIPTION
Are there any plans to add commands for other types of devices like oscillating or vibrating devices?
I would try to add them myself, and I have.... sort of, but not really.
I can barely program Rust. I just managed to move a linear motor to a certain position, but it doesn't seem to accept any arguments from the script. The only way I got it to work was to replace the commands from **VibrateIndex** with linear movement commands.

I also noticed some issues in the original version
If a command sent to a device fails, all devices stop working until the program is restarted.